### PR TITLE
Fix photo library permission on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Untuk platform Android plugin ini memerlukan permission `WRITE_EXTERNAL_STORAGE`
 
 ### iOS
 
-Untuk platform iOS plugin ini memerlukan permission `NSPhotoLibraryAddUsageDescription`. Oleha karena itu, kamu perlu tambahkan permission tersebut didalam file **Info.plist** seperti berikut.
+Untuk platform iOS plugin ini memerlukan permission `NSPhotoLibraryUsageDescription`. Oleha karena itu, kamu perlu tambahkan permission tersebut didalam file **Info.plist** seperti berikut.
 
 ```
 <?xml version="1.0" encoding="UTF-8"?>
@@ -29,8 +29,9 @@ Untuk platform iOS plugin ini memerlukan permission `NSPhotoLibraryAddUsageDescr
 <plist version="1.0">
 <dict>
 	...
-	<key>NSPhotoLibraryAddUsageDescription</key>
-    <string>Take pretty screenshots and save it to the PhotoLibrary.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Take pretty screenshots and save it to the PhotoLibrary.</string>
+	...
 </dict>
 </plist>
 

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -41,7 +41,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>NSPhotoLibraryAddUsageDescription</key>
+	<key>NSPhotoLibraryUsageDescription</key>
     <string>Take pretty screenshots and save it to the PhotoLibrary.</string>
 </dict>
 </plist>


### PR DESCRIPTION
Ubah 'NSPhotoLibraryAddUsageDescription` menjadi `NSPhotoLibraryUsageDescription' untuk photo library permission di iOS.