### PR TITLE
Bugfix - Perbaikan permission untuk Android 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,6 @@ Untuk platform Android plugin ini memerlukan permission `WRITE_EXTERNAL_STORAGE`
 
 ```
 
-Selain itu, kamu juga harus set `targetSdkVersion`-nya ke versi 29. Untuk mengubahnya silakan buka file **android/app/build.gradle** dan ubah nilai `targetSdkVersion`.
-```
-defaultConfig {
-    // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-    applicationId "id.net.nusa.plugin.flutter_feedback_example"
-    minSdkVersion 23
-    targetSdkVersion 29
-    versionCode flutterVersionCode.toInteger()
-    versionName flutterVersionName
-}
-```
-
 ### iOS
 
 Untuk platform iOS plugin ini memerlukan permission `NSPhotoLibraryUsageDescription`. Oleh karena itu, kamu perlu tambahkan permission tersebut didalam file **Info.plist** seperti berikut.

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -36,7 +36,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "id.net.nusa.plugin.flutter_feedback_example"
         minSdkVersion 23
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -15,7 +15,7 @@ def flutter_root
   unless File.exist?(generated_xcode_build_settings_path)
     raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
   end
-
+  
   File.foreach(generated_xcode_build_settings_path) do |line|
     matches = line.match(/FLUTTER_ROOT\=(.*)/)
     return matches[1].strip if matches
@@ -30,12 +30,64 @@ flutter_ios_podfile_setup
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
-
+  
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    
+    target.build_configurations.each do |config|
+      # You can remove unused permissions here
+      # for more infomation: https://github.com/BaseflowIT/flutter-permission-handler/blob/master/permission_handler/ios/Classes/PermissionHandlerEnums.h
+      # e.g. when you don't need camera permission, just add 'PERMISSION_CAMERA=0'
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+      '$(inherited)',
+      
+      ## dart: PermissionGroup.calendar
+      'PERMISSION_EVENTS=0',
+      
+      ## dart: PermissionGroup.reminders
+      'PERMISSION_REMINDERS=0',
+      
+      ## dart: PermissionGroup.contacts
+      'PERMISSION_CONTACTS=0',
+      
+      ## dart: PermissionGroup.camera
+      'PERMISSION_CAMERA=0',
+      
+      ## dart: PermissionGroup.microphone
+      'PERMISSION_MICROPHONE=0',
+      
+      ## dart: PermissionGroup.speech
+      'PERMISSION_SPEECH_RECOGNIZER=0',
+      
+      ## dart: PermissionGroup.photos
+      'PERMISSION_PHOTOS=1',
+      
+      ## dart: [PermissionGroup.location, PermissionGroup.locationAlways, PermissionGroup.locationWhenInUse]
+      'PERMISSION_LOCATION=0',
+      
+      ## dart: PermissionGroup.notification
+      'PERMISSION_NOTIFICATIONS=0',
+      
+      ## dart: PermissionGroup.mediaLibrary
+      'PERMISSION_MEDIA_LIBRARY=0',
+      
+      ## dart: PermissionGroup.sensors
+      'PERMISSION_SENSORS=0',
+      
+      ## dart: PermissionGroup.bluetooth
+      'PERMISSION_BLUETOOTH=0',
+      
+      ## dart: PermissionGroup.appTrackingTransparency
+      'PERMISSION_APP_TRACKING_TRANSPARENCY=0',
+      
+      ## dart: PermissionGroup.criticalAlerts
+      'PERMISSION_CRITICAL_ALERTS=0',
+      ]
+      
+    end
   end
 end

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -53,6 +53,7 @@ class _HomePageState extends State<HomePage> {
                       return FlutterFeedbackPluginPage(
                         File(result.path!),
                         (listScreenshots, category, description) async {
+                          // jika prosesnya berhasil
                           formFeedbackController.submitFeedback();
                           await Future.delayed(Duration(seconds: 3));
                           formFeedbackController.successFeedback(context);

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -132,6 +132,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  flutter_native_screenshot:
+    dependency: transitive
+    description:
+      name: flutter_native_screenshot
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.1"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -219,13 +226,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
-  native_screenshot:
-    dependency: transitive
-    description:
-      name: native_screenshot
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
   path:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -125,6 +125,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  flutter_native_screenshot:
+    dependency: "direct main"
+    description:
+      name: flutter_native_screenshot
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.1"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -212,13 +219,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
-  native_screenshot:
-    dependency: "direct main"
-    description:
-      name: native_screenshot
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
   path:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   permission_handler: ^8.1.1
-  native_screenshot: ^1.0.0
+  flutter_native_screenshot: ^1.1.1
   path: ^1.8.0
   path_provider: ^2.0.2
   flutter_image_compress: ^1.0.0


### PR DESCRIPTION
Perbaikan untuk Android 11 yang tidak bisa ambil screenshot ketika pertama kali allow-kan runtime permission-nya. Penyebabnya ada di plugin `native_screenshot`-nya yang belum support untuk Android 11. Sekarang sudah diubah ke plugin `flutter_native_screenshot` yang support untuk Android 11.