### PR TITLE
Set warna default dari teks didalam widget `CupertinoActionSheetAction`

### DIFF
--- a/lib/page/form_feedback/flutter_feedback_plugin_page.dart
+++ b/lib/page/form_feedback/flutter_feedback_plugin_page.dart
@@ -385,18 +385,21 @@ class _FlutterFeedbackPluginPageState extends State<FlutterFeedbackPluginPage> {
                 CupertinoActionSheetAction(
                   child: Text(
                     _locale.viewScreenshot(),
+                    style: TextStyle(color: Colors.blue),
                   ),
                   onPressed: () => Navigator.pop(context, 'view'),
                 ),
                 CupertinoActionSheetAction(
                   child: Text(
                     _locale.editScreenshot(),
+                    style: TextStyle(color: Colors.blue),
                   ),
                   onPressed: () => Navigator.pop(context, 'edit'),
                 ),
                 CupertinoActionSheetAction(
                   child: Text(
                     _locale.deleteScreenshot(),
+                    style: TextStyle(color: Colors.red),
                   ),
                   isDestructiveAction: true,
                   onPressed: () => Navigator.pop(context, 'delete'),


### PR DESCRIPTION
Set warna default dari teks untuk widget `CupertinoActionSheetAction`. Hal ini perlu diset karena jika tidak maka, akan ambil warna default dari theme app.