### PR TITLE
Export class model `DeviceLogs`

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -173,7 +173,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.3.2"
+    version: "2.4.0"
   flutter_image_compress:
     dependency: transitive
     description:

--- a/lib/flutter_feedback.dart
+++ b/lib/flutter_feedback.dart
@@ -12,6 +12,7 @@ import 'src/data/enum/status.dart';
 import 'src/data/model/status_screenshot/status_screenshot.dart';
 
 export 'src/data/enum/status.dart';
+export 'src/data/model/device_logs/device_logs.dart';
 export 'src/page/form_feedback/flutter_feedback_plugin_page.dart';
 
 /// Class ini berfungsi untuk membuat fitur feedback dengan cara mengambil screenshot layar.


### PR DESCRIPTION
Export class model `DeviceLogs` didalam flutter_feedback.dart. Hal ini dibuat agar pengguna plugin-nya bisa menggunakan class model-nya langsung tanpa perlu import path class model-nya. Cukup import `flutter_feedback.dart`-nya saja.